### PR TITLE
Fix stepsize error for rectangular partitions

### DIFF
--- a/src/StateSpaceReconstruction.jl
+++ b/src/StateSpaceReconstruction.jl
@@ -8,9 +8,6 @@ using DynamicalSystems
 using StaticArrays
 
 include("embedding/delaunay_colwise.jl") # include before embedding
-
-
-
 include("embedding/embedding_colwise.jl")
 
 
@@ -35,11 +32,8 @@ function delaunaytriang(E::AbstractEmbedding; noise_factor = 0.01)
     triang = delaunay(transpose(E.points))
     return DelaunayTriangulation(hcat(triang...))
 end
-
-
-include("embedding/invariantize_colwise.jl")
-
 include("partitioning/Partitioning.jl")
+include("embedding/invariantize_colwise.jl")
 
 export delaunaytriang
 end # module

--- a/test/embedding.jl
+++ b/test/embedding.jl
@@ -1,0 +1,86 @@
+using DynamicalSystems.Dataset
+
+@testset "Alignment with and without zero-lagged vector matches" begin
+    ts = [rand(12) for i = 1:3]
+    E1 = embed(ts, [1, 2, 3, 3], [1, -1, -1, 0])
+    E2 = embed(ts, [1, 2, 3], [1, -1, -1])
+
+    @test all(E1.points[:, 1:3] .== E2.points)
+    @test typeof(E1) <: AbstractEmbedding
+    @test typeof(E2) <: AbstractEmbedding
+end
+
+
+@testset "Embedding dim > 3" begin
+    ts2 = [rand(10) for i = 1:3]
+    ts3 = [collect(1:10) for i = 1:5]
+    # Floats
+    E1 = embed(ts2, [1, 2, 3, 3], [1, -1, -1, 0])
+    E2 = embed(ts2, [1, 2, 3], [1, -1, -1])
+
+    # Integers
+    E3 = embed(ts3, [1, 2, 3, 3, 1], [1, -1, -1, 0, 1])
+    E4 = embed(ts3, [1, 2, 3], [1, -1, -1])
+
+    @test all(E1.points[:, 1:3] .== E2.points)
+    @test all(E3.points[:, 1:3] .== E4.points)
+
+    @test typeof(E1) <: AbstractEmbedding
+    @test typeof(E2) <: AbstractEmbedding
+    @test typeof(E3) <: AbstractEmbedding
+    @test typeof(E4) <: AbstractEmbedding
+end
+
+
+@testset "Multiple dispatch" begin
+    u = [randn(10) for i = 1:3]
+    v = [collect(1:10) for i = 1:3]
+    A = randn(10, 3)
+    B = hcat(v...)
+    D = Dataset(A)
+    ts_inds = [1, 2, 3]
+    embedding_lags = [1, 0, -2]
+
+    # Vector of vectors
+    @test typeof(embed(u)) <: AbstractEmbedding
+    @test typeof(embed(v)) <: AbstractEmbedding
+    @test typeof(embed(u, ts_inds, embedding_lags)) <: AbstractEmbedding
+    @test typeof(embed(v, ts_inds, embedding_lags)) <: AbstractEmbedding
+
+    # Arrays
+    @test typeof(embed(A)) <: AbstractEmbedding
+    @test typeof(embed(A, ts_inds, embedding_lags)) <: AbstractEmbedding
+
+    @test typeof(embed(float.(B))) <: AbstractEmbedding
+    @test typeof(embed(float.(B), ts_inds, embedding_lags)) <: AbstractEmbedding
+
+    # Datasets
+    @test typeof(embed(D)) <: AbstractEmbedding
+end
+
+
+@testset "Invariantizing embeddings" begin
+    pos = [1, 2, 3, 3]
+    lags = [1, -1, -1, 0]
+    E1 = embed([diff(rand(30)) for i = 1:4], pos, lags)
+    E2 = embed([diff(rand(1:10, 30)) for i = 1:4], pos, lags)
+    inv_E1 = invariantize(E1)
+    inv_E2 = invariantize(E2)
+
+    @test typeof(inv_E1) == LinearlyInvariantEmbedding{Float64}
+    @test typeof(inv_E2) == LinearlyInvariantEmbedding{Int}
+#end
+
+
+@testset "Plotting recipes" begin
+    emb = embed([diff(rand(30)) for i = 1:3], [1, 2, 3], [1, 0, -1])
+    emb_invariant = invariantize(emb)
+
+    # Test plot recipes by calling RecipesBase.apply_recipe with empty dict.
+    # It should return a vector of RecipesBase.RecipeData
+    d = Dict{Symbol,Any}()
+
+    @test typeof(RecipesBase.apply_recipe(d, emb)) == Array{RecipesBase.RecipeData,1}
+    @test typeof(RecipesBase.apply_recipe(d, emb_invariant)) == Array{RecipesBase.RecipeData,1}
+
+end

--- a/test/embedding_colwise.jl
+++ b/test/embedding_colwise.jl
@@ -38,6 +38,25 @@ end
 	tri = delaunaytriang(E1a)
 	@test typeof(inv) <: LinearlyInvariantEmbedding
 	@test typeof(tri) <: DelaunayTriangulation
+end
 
+@testset "Alignment with and without zero-lagged vector matches" begin
+    ts = [rand(12) for i = 1:3]
+    E1 = embed(ts, [1, 2, 3, 3], [1, -1, -1, 0])
+    E2 = embed(ts, [1, 2, 3], [1, -1, -1])
 
+    @test all(E1.points[1:3, :] .== E2.points)
+    @test typeof(E1) <: AbstractEmbedding
+    @test typeof(E2) <: AbstractEmbedding
+end
+
+@testset "Plotting recipes" begin
+    emb = embed([diff(rand(30)) for i = 1:3], [1, 2, 3], [1, 0, -1])
+    emb_invariant = invariantize(emb)
+
+    # Test plot recipes by calling RecipesBase.apply_recipe with empty dict.
+    # It should return a vector of RecipesBase.RecipeData
+    d = Dict{Symbol,Any}()
+    @test typeof(RecipesBase.apply_recipe(d, emb)) == Array{RecipesBase.RecipeData,1}
+    @test typeof(RecipesBase.apply_recipe(d, emb_invariant)) == Array{RecipesBase.RecipeData,1}
 end


### PR DESCRIPTION
Step size error and bin assignment fixed for rectangular partitions. Coverings now look like this for the different types of rectangular bin schemes:

<img width="594" alt="bin_coverings_after_fix" src="https://user-images.githubusercontent.com/5237566/45085733-b2f0a880-b101-11e8-9ec7-4da07f52c0ea.png">
